### PR TITLE
Fix Get ResourceBundle with properties from the DB

### DIFF
--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/activities/FormConfigurationJsonFormActivity.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/activities/FormConfigurationJsonFormActivity.java
@@ -109,7 +109,7 @@ public class FormConfigurationJsonFormActivity extends JsonFormActivity {
     protected String getJsonForm() {
         String jsonForm = getIntent().getStringExtra(JsonFormConstants.JSON_FORM_KEY.JSON);
         if (translateForm) {
-            jsonForm = NativeFormLangUtils.getTranslatedStringWithDBResourceBundle(jsonForm, null);
+            jsonForm = NativeFormLangUtils.getTranslatedStringWithDBResourceBundle(this, jsonForm, null);
         }
         return jsonForm;
     }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/constants/JsonFormConstants.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/constants/JsonFormConstants.java
@@ -221,6 +221,7 @@ public class JsonFormConstants {
     public static final String FORM_NAME = "form_name";
     public static final String FORM_CONFIG_LOCATION = "json.form/json.form.config.json";
 
+    public static final String PROPERTIES_FILE_EXTENSION = ".properties";
     public static final String JSON_FILE_EXTENSION = ".json";
     public static final String CLIENT_FORM_ASSET_VERSION = "base version";
 

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundle.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundle.java
@@ -16,16 +16,16 @@ public class DBResourceBundle extends ListResourceBundle {
 
     @Override
     protected Object[][] getContents() {
-        if (StringUtils.isNotBlank(this.identifier)) {
-            FormUtils formUtils = new FormUtils();
-            String propertiesString = formUtils.getPropertiesFileContentsFromDB(identifier);
+        Object[][] properties = new Object[0][];
+        FormUtils formUtils = new FormUtils();
+        String propertiesString = formUtils.getPropertiesFileContentsFromDB(identifier);
+        if (StringUtils.isNotBlank(propertiesString)) {
             String[] propertiesArray = propertiesString.split("\n");
-            Object[][] properties = new Object[propertiesArray.length][];
+            properties = new Object[propertiesArray.length][];
             for (int i = 0; i < propertiesArray.length; i++) {
                 properties[i] = propertiesArray[i].trim().split("\\s*=\\s*");
             }
-            return properties;
         }
-        return null;
+        return properties;
     }
 }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundle.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundle.java
@@ -1,31 +1,17 @@
 package com.vijay.jsonwizard.domain;
 
-import com.vijay.jsonwizard.utils.FormUtils;
-
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.ListResourceBundle;
 
 public class DBResourceBundle extends ListResourceBundle {
 
-    private String identifier;
+    private Object[][] properties;
 
-    public DBResourceBundle(String identifier) {
-        this.identifier = identifier;
+    public DBResourceBundle(Object[][] properties) {
+        this.properties = properties;
     }
 
     @Override
     protected Object[][] getContents() {
-        Object[][] properties = new Object[0][];
-        FormUtils formUtils = new FormUtils();
-        String propertiesString = formUtils.getPropertiesFileContentsFromDB(identifier);
-        if (StringUtils.isNotBlank(propertiesString)) {
-            String[] propertiesArray = propertiesString.split("\n");
-            properties = new Object[propertiesArray.length][];
-            for (int i = 0; i < propertiesArray.length; i++) {
-                properties[i] = propertiesArray[i].trim().split("\\s*=\\s*");
-            }
-        }
-        return properties;
+        return this.properties;
     }
 }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundleControl.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundleControl.java
@@ -18,4 +18,8 @@ public class DBResourceBundleControl extends ResourceBundle.Control {
         return new DBResourceBundle(identifier);
     }
 
+    // Don't cache since the DBResourceBundle handles properties for different Locales
+    public long getTimeToLive(String arg0, Locale arg1) {
+        return TTL_DONT_CACHE;
+    }
 }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundleControl.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundleControl.java
@@ -1,5 +1,9 @@
 package com.vijay.jsonwizard.domain;
 
+import com.vijay.jsonwizard.utils.FormUtils;
+
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.Locale;
 import java.util.ResourceBundle;
 
@@ -15,11 +19,28 @@ public class DBResourceBundleControl extends ResourceBundle.Control {
     public ResourceBundle newBundle(String baseName, Locale locale, String format, ClassLoader loader, boolean reload)
             throws IllegalAccessException,
             InstantiationException {
-        return new DBResourceBundle(identifier);
+        return new DBResourceBundle(getPropertiesFromRepository(identifier));
     }
 
     // Don't cache since the DBResourceBundle handles properties for different Locales
     public long getTimeToLive(String arg0, Locale arg1) {
         return TTL_DONT_CACHE;
+    }
+
+    private Object[][] getPropertiesFromRepository(String identifier) {
+        Object[][] properties = new Object[0][];
+        if (StringUtils.isNotBlank(this.identifier)) {
+            FormUtils formUtils = new FormUtils();
+            String propertiesString = formUtils.getPropertiesFileContentsFromDB(identifier);
+            if (StringUtils.isNotBlank(propertiesString)) {
+                String[] propertiesArray = propertiesString.split("\n");
+                properties = new Object[propertiesArray.length][];
+                for (int i = 0; i < propertiesArray.length; i++) {
+                    properties[i] = propertiesArray[i].trim().split("\\s*=\\s*");
+                }
+            }
+
+        }
+        return properties;
     }
 }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundleControl.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/domain/DBResourceBundleControl.java
@@ -23,6 +23,7 @@ public class DBResourceBundleControl extends ResourceBundle.Control {
     }
 
     // Don't cache since the DBResourceBundle handles properties for different Locales
+    @Override
     public long getTimeToLive(String arg0, Locale arg1) {
         return TTL_DONT_CACHE;
     }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/FormUtils.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/FormUtils.java
@@ -2020,7 +2020,7 @@ public class FormUtils {
             String originalJson = clientForm.getJson();
 
             if (translateSubForm) {
-                originalJson = NativeFormLangUtils.getTranslatedStringWithDBResourceBundle(originalJson, null);
+                originalJson = NativeFormLangUtils.getTranslatedStringWithDBResourceBundle(context, originalJson, null);
             }
             return new JSONObject(originalJson);
         }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/NativeFormLangUtils.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/NativeFormLangUtils.java
@@ -8,6 +8,7 @@ import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
+import com.vijay.jsonwizard.constants.JsonFormConstants;
 import com.vijay.jsonwizard.domain.DBResourceBundle;
 import com.vijay.jsonwizard.domain.DBResourceBundleControl;
 
@@ -120,7 +121,7 @@ public class NativeFormLangUtils {
         if (dbResourceBundle == null) {
             mlsResourceBundle = getResourceBundleFromRepository(str);
         }
-        return (mlsResourceBundle == null) ? getTranslatedString(str) : translateString(str, mlsResourceBundle);
+        return (mlsResourceBundle != null && mlsResourceBundle.getKeys().hasMoreElements()) ? translateString(str, mlsResourceBundle) : getTranslatedString(str);
     }
 
     /**
@@ -173,8 +174,8 @@ public class NativeFormLangUtils {
         return matcher.find() ? matcher.group(1) : "";
     }
 
-    @Nullable
     public static ResourceBundle getResourceBundleFromRepository(String form) {
-        return ResourceBundle.getBundle(DBResourceBundle.class.getCanonicalName(), new DBResourceBundleControl(getTranslationsFileName(form)));
+        String identifier = getTranslationsFileName(form) + JsonFormConstants.PROPERTIES_FILE_EXTENSION;
+        return ResourceBundle.getBundle(DBResourceBundle.class.getCanonicalName(), new DBResourceBundleControl(identifier));
     }
 }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/NativeFormLangUtils.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/NativeFormLangUtils.java
@@ -116,10 +116,10 @@ public class NativeFormLangUtils {
         return translatedString;
     }
 
-    public static String getTranslatedStringWithDBResourceBundle(String str, ResourceBundle dbResourceBundle) {
+    public static String getTranslatedStringWithDBResourceBundle(Context context, String str, ResourceBundle dbResourceBundle) {
         ResourceBundle mlsResourceBundle = dbResourceBundle;
         if (dbResourceBundle == null) {
-            mlsResourceBundle = getResourceBundleFromRepository(str);
+            mlsResourceBundle = getResourceBundleFromRepository(context, str);
         }
         return (mlsResourceBundle != null && mlsResourceBundle.getKeys().hasMoreElements()) ? translateString(str, mlsResourceBundle) : getTranslatedString(str);
     }
@@ -174,8 +174,14 @@ public class NativeFormLangUtils {
         return matcher.find() ? matcher.group(1) : "";
     }
 
-    public static ResourceBundle getResourceBundleFromRepository(String form) {
-        String identifier = getTranslationsFileName(form) + JsonFormConstants.PROPERTIES_FILE_EXTENSION;
+    public static ResourceBundle getResourceBundleFromRepository(Context context, String form) {
+        //Check the current locale of the app to load the correct version of the properties in the desired language
+        String locale = context.getResources().getConfiguration().locale.getLanguage();
+        String identifier = getTranslationsFileName(form);
+        if (!Locale.ENGLISH.getLanguage().equals(locale)) {
+            identifier = identifier + "_" + locale;
+        }
+         identifier = identifier + JsonFormConstants.PROPERTIES_FILE_EXTENSION;
         return ResourceBundle.getBundle(DBResourceBundle.class.getCanonicalName(), new DBResourceBundleControl(identifier));
     }
 }

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/Utils.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/utils/Utils.java
@@ -635,6 +635,18 @@ public class Utils {
     }
 
     /**
+     * Translates a yaml file specified by {@param fileName} using properties stored in the database
+     * and returns its String representation
+     *
+     * @param fileName
+     * @param context
+     * @return Translated Yaml file in its String representation
+     */
+    public static String getTranslatedYamlFileWithDBProperties(String fileName, Context context) {
+        return NativeFormLangUtils.getTranslatedStringWithDBResourceBundle(context, getAssetFileAsString(fileName, context), null);
+    }
+
+    /**
      * Gets the contents of a file specified by {@param fileName} from the assets folder as a {@link String}
      *
      * @param fileName

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
@@ -1,5 +1,6 @@
 package com.vijay.jsonwizard.utils;
 
+import android.content.Context;
 import android.preference.PreferenceManager;
 
 import com.vijay.jsonwizard.BaseTest;
@@ -18,7 +19,6 @@ import java.util.ResourceBundle;
 import static com.vijay.jsonwizard.utils.Utils.getTranslatedYamlFile;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Vincent Karuri on 20/02/2020
@@ -90,18 +90,21 @@ public class NativeFormLangUtilsTest extends BaseTest {
     public void testCanGetResourceBundleWithPropertiesFromRepository() {
         ClientFormContract.Dao clientFormRepository = Mockito.mock(ClientFormContract.Dao.class);
         NativeFormLibrary.getInstance().setClientFormDao(clientFormRepository);
-        String properties = "step1.title = New client record\nstep1.previous_label = SAVE AND EXIT";
+        Context context = RuntimeEnvironment.application;
+        String enProperties = "step1.title = New client record\nstep1.previous_label = SAVE AND EXIT";
         String interpolatedJsonForm = testUtils.getResourceFileContentsAsString("test_form_translation_interpolated");
 
         ClientFormContract.Model clientForm = new TestClientForm();
-        clientForm.setJson(properties);
-        Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
 
-        ResourceBundle.clearCache();
-        ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm);
-        assertTrue(mlsResourceBundle.getKeys().hasMoreElements());
-        assertEquals("New client record", mlsResourceBundle.getString("step1.title"));
-        assertEquals("SAVE AND EXIT", mlsResourceBundle.getString("step1.previous_label"));
+        clientForm.setJson(enProperties);
+        Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
+        assertEquals("SAVE AND EXIT",  NativeFormLangUtils.getResourceBundleFromRepository(RuntimeEnvironment.application, interpolatedJsonForm).getString("step1.previous_label"));
+
+        String swProperties = "step1.title = Rekodi mpya\nstep1.previous_label = WEKA ALAFU ONDOKA";
+        clientForm.setJson(swProperties);
+        NativeFormLangUtils.setAppLocale(context, "sw");
+        Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings_sw.properties"));
+        assertEquals("Rekodi mpya",  NativeFormLangUtils.getResourceBundleFromRepository(RuntimeEnvironment.application, interpolatedJsonForm).getString("step1.title"));
     }
 
     @Test
@@ -112,8 +115,7 @@ public class NativeFormLangUtilsTest extends BaseTest {
 
         Mockito.doReturn(null).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
 
-        ResourceBundle.clearCache();
-        ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm);
+        ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(RuntimeEnvironment.application, interpolatedJsonForm);
         assertFalse(mlsResourceBundle.getKeys().hasMoreElements());
     }
 }

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
@@ -13,9 +13,12 @@ import org.robolectric.RuntimeEnvironment;
 import org.smartregister.client.utils.contract.ClientFormContract;
 
 import java.util.Locale;
+import java.util.ResourceBundle;
 
 import static com.vijay.jsonwizard.utils.Utils.getTranslatedYamlFile;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Created by Vincent Karuri on 20/02/2020
@@ -94,6 +97,20 @@ public class NativeFormLangUtilsTest extends BaseTest {
         clientForm.setJson(properties);
         Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
 
-        assertEquals("New client record", NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm).getString("step1.title"));
+        ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm);
+        assertTrue(mlsResourceBundle.getKeys().hasMoreElements());
+        assertEquals("New client record", mlsResourceBundle.getString("step1.title"));
+    }
+
+    @Test
+    public void testResourceBundleWithPropertiesFromDbIsEmptyWhenClientFormDoesntExist() {
+        ClientFormContract.Dao clientFormRepository = Mockito.mock(ClientFormContract.Dao.class);
+        NativeFormLibrary.getInstance().setClientFormDao(clientFormRepository);
+        String interpolatedJsonForm = testUtils.getResourceFileContentsAsString("test_form_translation_interpolated");
+
+        Mockito.doReturn(null).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
+
+        ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm);
+        assertFalse(mlsResourceBundle.getKeys().hasMoreElements());
     }
 }

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
@@ -87,7 +87,7 @@ public class NativeFormLangUtilsTest extends BaseTest {
     }
 
     @Test
-    public void canGetResourceBundleWithPropertiesFromRepository() {
+    public void testCanGetResourceBundleWithPropertiesFromRepository() {
         ClientFormContract.Dao clientFormRepository = Mockito.mock(ClientFormContract.Dao.class);
         NativeFormLibrary.getInstance().setClientFormDao(clientFormRepository);
         String properties = "step1.title = New client record\nstep1.previous_label = SAVE AND EXIT";
@@ -97,9 +97,11 @@ public class NativeFormLangUtilsTest extends BaseTest {
         clientForm.setJson(properties);
         Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
 
+        ResourceBundle.clearCache();
         ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm);
         assertTrue(mlsResourceBundle.getKeys().hasMoreElements());
         assertEquals("New client record", mlsResourceBundle.getString("step1.title"));
+        assertEquals("SAVE AND EXIT", mlsResourceBundle.getString("step1.previous_label"));
     }
 
     @Test
@@ -110,6 +112,7 @@ public class NativeFormLangUtilsTest extends BaseTest {
 
         Mockito.doReturn(null).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
 
+        ResourceBundle.clearCache();
         ResourceBundle mlsResourceBundle = NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm);
         assertFalse(mlsResourceBundle.getKeys().hasMoreElements());
     }

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/utils/NativeFormLangUtilsTest.java
@@ -92,7 +92,7 @@ public class NativeFormLangUtilsTest extends BaseTest {
 
         ClientFormContract.Model clientForm = new TestClientForm();
         clientForm.setJson(properties);
-        Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings"));
+        Mockito.doReturn(clientForm).when(clientFormRepository).getActiveClientFormByIdentifier(Mockito.eq("form_strings.properties"));
 
         assertEquals("New client record", NativeFormLangUtils.getResourceBundleFromRepository(interpolatedJsonForm).getString("step1.title"));
     }


### PR DESCRIPTION
- Added `.properties` file extension when retrieving properties details
- Handled loading properties based on Locale
- Fixed retrieving `Object[][]` when getting ResourceBundle - return empty array instead of `null`
- Disabled Caching of properties since the DBResourceBundle handles different properties and locales
- Updated tests to test getting properties with different Locales


---
Related issues
- https://github.com/OpenSRP/opensrp-client-anc/issues/524
- https://github.com/OpenSRP/opensrp-client-core/issues/547
- https://github.com/OpenSRP/opensrp-client-anc/issues/521
- https://github.com/OpenSRP/opensrp-client-anc/issues/527